### PR TITLE
Upgrade CLI version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: install lint
-        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
       - name: lint
         run: golangci-lint run
       - name: test

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # go-webapp-sample
 
+![license](https://img.shields.io/github/license/ybkuroki/go-webapp-sample?style=for-the-badge)
+![workflow](https://img.shields.io/github/workflow/status/ybkuroki/go-webapp-sample/check?label=check&style=for-the-badge&logo=github)
+![release](https://img.shields.io/github/release/ybkuroki/go-webapp-sample?style=for-the-badge&logo=github)
+
 ## Preface
 This sample project uses [Echo](https://echo.labstack.com/) and [Gorm](https://gorm.io/) written by [Golang](https://golang.org/). It provides only Web API. So, I recommend using a [vuejs-webapp-sample](https://github.com/ybkuroki/vuejs-webapp-sample) project as Web UI.
 
 ## Install
 Perform the following steps:
+1. Download and install [MinGW(gcc)](https://sourceforge.net/projects/mingw-w64/files/?source=navbar).
 1. Download and install [Visual Studio Code(VS Code)](https://code.visualstudio.com/).
 1. Download and install [Golang](https://golang.org/).
 1. Get the source code of this repository by the following command.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-webapp-sample
 
-![license](https://img.shields.io/github/license/ybkuroki/go-webapp-sample?style=for-the-badge)
-![workflow](https://img.shields.io/github/workflow/status/ybkuroki/go-webapp-sample/check?label=check&style=for-the-badge&logo=github)
-![release](https://img.shields.io/github/release/ybkuroki/go-webapp-sample?style=for-the-badge&logo=github)
+[![license](https://img.shields.io/github/license/ybkuroki/go-webapp-sample?style=for-the-badge)](https://github.com/ybkuroki/go-webapp-sample/blob/master/LICENSE)
+[![workflow](https://img.shields.io/github/workflow/status/ybkuroki/go-webapp-sample/check?label=check&style=for-the-badge&logo=github)](https://github.com/ybkuroki/go-webapp-sample/actions?query=workflow%3Acheck)
+[![release](https://img.shields.io/github/release/ybkuroki/go-webapp-sample?style=for-the-badge&logo=github)](https://github.com/ybkuroki/go-webapp-sample/releases)
 
 ## Preface
 This sample project uses [Echo](https://echo.labstack.com/) and [Gorm](https://gorm.io/) written by [Golang](https://golang.org/). It provides only Web API. So, I recommend using a [vuejs-webapp-sample](https://github.com/ybkuroki/vuejs-webapp-sample) project as Web UI.


### PR DESCRIPTION
Changes proposed in this pull request:

- Upgrade golangcli-lint from 1.18 to 1.27 in GitHub actions.
- Add badges in README.
- Add procedure that install gcc in README.