### PR TITLE
Fix session context corrupted problem

### DIFF
--- a/controller/account.go
+++ b/controller/account.go
@@ -59,7 +59,7 @@ func (controller *accountController) GetLoginAccount(c echo.Context) error {
 	if !controller.context.GetConfig().Extension.SecurityEnabled {
 		return c.JSON(http.StatusOK, controller.dummyAccount)
 	}
-	return c.JSON(http.StatusOK, controller.context.GetSession().GetAccount())
+	return c.JSON(http.StatusOK, controller.context.GetSession().GetAccount(c))
 }
 
 // Login is the method to login using username and password by http post.
@@ -79,14 +79,14 @@ func (controller *accountController) Login(c echo.Context) error {
 	}
 
 	sess := controller.context.GetSession()
-	if account := sess.GetAccount(); account != nil {
+	if account := sess.GetAccount(c); account != nil {
 		return c.JSON(http.StatusOK, account)
 	}
 
 	authenticate, a := controller.service.AuthenticateByUsernameAndPassword(dto.UserName, dto.Password)
 	if authenticate {
-		_ = sess.SetAccount(a)
-		_ = sess.Save()
+		_ = sess.SetAccount(c, a)
+		_ = sess.Save(c)
 		return c.JSON(http.StatusOK, a)
 	}
 	return c.NoContent(http.StatusUnauthorized)
@@ -102,7 +102,7 @@ func (controller *accountController) Login(c echo.Context) error {
 // @Router /auth/logout [post]
 func (controller *accountController) Logout(c echo.Context) error {
 	sess := controller.context.GetSession()
-	_ = sess.SetAccount(nil)
-	_ = sess.Delete()
+	_ = sess.SetAccount(c, nil)
+	_ = sess.Delete(c)
 	return c.NoContent(http.StatusOK)
 }

--- a/controller/session_test.go
+++ b/controller/session_test.go
@@ -23,15 +23,15 @@ func TestSessionRace_Success(t *testing.T) {
 	session := sessionController{container: container}
 
 	router.GET(config.API+"1", func(c echo.Context) error {
-		_ = session.container.GetSession().SetValue(sessionKey, 1)
-		_ = session.container.GetSession().Save()
+		_ = session.container.GetSession().SetValue(c, sessionKey, 1)
+		_ = session.container.GetSession().Save(c)
 		time.Sleep(3 * time.Second)
-		return c.String(http.StatusOK, session.container.GetSession().GetValue(sessionKey))
+		return c.String(http.StatusOK, session.container.GetSession().GetValue(c, sessionKey))
 	})
 	router.GET(config.API+"2", func(c echo.Context) error {
-		_ = session.container.GetSession().SetValue(sessionKey, 2)
-		_ = session.container.GetSession().Save()
-		return c.String(http.StatusOK, session.container.GetSession().GetValue(sessionKey))
+		_ = session.container.GetSession().SetValue(c, sessionKey, 2)
+		_ = session.container.GetSession().Save(c)
+		return c.String(http.StatusOK, session.container.GetSession().GetValue(c, sessionKey))
 	})
 
 	req1 := httptest.NewRequest("GET", config.API+"1", nil)

--- a/controller/session_test.go
+++ b/controller/session_test.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/ybkuroki/go-webapp-sample/config"
+	"github.com/ybkuroki/go-webapp-sample/container"
+	"github.com/ybkuroki/go-webapp-sample/test"
+)
+
+type sessionController struct {
+	container container.Container
+}
+
+func TestSessionRace_Success(t *testing.T) {
+	sessionKey := "Key"
+	router, container := test.PrepareForControllerTest(true)
+	session := sessionController{container: container}
+
+	router.GET(config.API+"1", func(c echo.Context) error {
+		_ = session.container.GetSession().SetValue(sessionKey, 1)
+		_ = session.container.GetSession().Save()
+		time.Sleep(3 * time.Second)
+		return c.String(http.StatusOK, session.container.GetSession().GetValue(sessionKey))
+	})
+	router.GET(config.API+"2", func(c echo.Context) error {
+		_ = session.container.GetSession().SetValue(sessionKey, 2)
+		_ = session.container.GetSession().Save()
+		return c.String(http.StatusOK, session.container.GetSession().GetValue(sessionKey))
+	})
+
+	req1 := httptest.NewRequest("GET", config.API+"1", nil)
+	req2 := httptest.NewRequest("GET", config.API+"2", nil)
+	rec1 := httptest.NewRecorder()
+	rec2 := httptest.NewRecorder()
+
+	go func() {
+		router.ServeHTTP(rec1, req1)
+	}()
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		router.ServeHTTP(rec2, req2)
+	}()
+
+	time.Sleep(5 * time.Second)
+
+	assert.Equal(t, "1", rec1.Body.String())
+	assert.Equal(t, "2", rec2.Body.String())
+}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	logger.GetZapLogger().Infof("Loaded messages.properties")
 
 	rep := repository.NewBookRepository(logger, conf)
-	sess := session.NewSession()
+	sess := session.NewSession(logger, conf)
 	container := container.NewContainer(rep, sess, conf, messages, logger, env)
 
 	migration.CreateDatabase(container)

--- a/session/session.go
+++ b/session/session.go
@@ -2,12 +2,14 @@ package session
 
 import (
 	"encoding/json"
-	"net/http"
+	"fmt"
 
 	"github.com/gorilla/sessions"
-	echoSession "github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
+	"github.com/ybkuroki/go-webapp-sample/config"
+	"github.com/ybkuroki/go-webapp-sample/logger"
 	"github.com/ybkuroki/go-webapp-sample/model"
+	"gopkg.in/boj/redistore.v1"
 )
 
 const (
@@ -18,79 +20,92 @@ const (
 )
 
 type session struct {
-	context echo.Context
+	store sessions.Store
 }
 
 // Session represents a interface for accessing the session on the application.
 type Session interface {
-	SetContext(c echo.Context)
-	Get() *sessions.Session
-	Save() error
-	Delete() error
-	SetValue(key string, value interface{}) error
-	GetValue(key string) string
-	SetAccount(account *model.Account) error
-	GetAccount() *model.Account
+	GetStore() sessions.Store
+
+	Get(c echo.Context) *sessions.Session
+	Save(c echo.Context) error
+	Delete(c echo.Context) error
+	SetValue(c echo.Context, key string, value interface{}) error
+	GetValue(c echo.Context, key string) string
+	SetAccount(c echo.Context, account *model.Account) error
+	GetAccount(c echo.Context) *model.Account
 }
 
 // NewSession is constructor.
-func NewSession() Session {
-	return &session{context: nil}
+func NewSession(logger logger.Logger, conf *config.Config) Session {
+	if !conf.Redis.Enabled {
+		logger.GetZapLogger().Infof("use CookieStore for session")
+		return &session{sessions.NewCookieStore([]byte("secret"))}
+	}
+
+	logger.GetZapLogger().Infof("use redis for session")
+	logger.GetZapLogger().Infof("Try redis connection")
+	address := fmt.Sprintf("%s:%s", conf.Redis.Host, conf.Redis.Port)
+	store, err := redistore.NewRediStore(conf.Redis.ConnectionPoolSize, "tcp", address, "", []byte("secret"))
+	if err != nil {
+		logger.GetZapLogger().Panicf("Failure redis connection, %s", err.Error())
+	}
+	logger.GetZapLogger().Infof(fmt.Sprintf("Success redis connection, %s", address))
+	return &session{store: store}
 }
 
-// SetContext sets the context of echo framework to the session.
-func (s *session) SetContext(c echo.Context) {
-	s.context = c
+func (s *session) GetStore() sessions.Store {
+	return s.store
 }
 
 // Get returns a session for the current request.
-func (s *session) Get() *sessions.Session {
-	sess, _ := echoSession.Get(sessionStr, s.context)
+func (s *session) Get(c echo.Context) *sessions.Session {
+	sess, _ := s.store.Get(c.Request(), sessionStr)
 	return sess
 }
 
 // Save saves the current session.
-func (s *session) Save() error {
-	sess := s.Get()
+func (s *session) Save(c echo.Context) error {
+	sess := s.Get(c)
 	sess.Options = &sessions.Options{
 		Path:     "/",
 		HttpOnly: true,
 	}
-	return s.saveSession(sess)
+	return s.saveSession(c, sess)
 }
 
 // Delete the current session.
-func (s *session) Delete() error {
-	sess := s.Get()
+func (s *session) Delete(c echo.Context) error {
+	sess := s.Get(c)
 	sess.Options = &sessions.Options{
 		Path:     "/",
 		HttpOnly: true,
 		MaxAge:   -1,
 	}
-	return s.saveSession(sess)
+	return s.saveSession(c, sess)
 }
 
-func (s *session) saveSession(sess *sessions.Session) error {
-	if err := sess.Save(s.context.Request(), s.context.Response()); err != nil {
-		return s.context.NoContent(http.StatusInternalServerError)
+func (s *session) saveSession(c echo.Context, sess *sessions.Session) error {
+	if err := sess.Save(c.Request(), c.Response()); err != nil {
+		return fmt.Errorf("error occurred while save session")
 	}
 	return nil
 }
 
 // SetValue sets a key and a value.
-func (s *session) SetValue(key string, value interface{}) error {
-	sess := s.Get()
+func (s *session) SetValue(c echo.Context, key string, value interface{}) error {
+	sess := s.Get(c)
 	bytes, err := json.Marshal(value)
 	if err != nil {
-		return s.context.NoContent(http.StatusInternalServerError)
+		return fmt.Errorf("json marshal error while set value in session")
 	}
 	sess.Values[key] = string(bytes)
 	return nil
 }
 
 // GetValue returns value of session.
-func (s *session) GetValue(key string) string {
-	sess := s.Get()
+func (s *session) GetValue(c echo.Context, key string) string {
+	sess := s.Get(c)
 	if sess != nil {
 		if v, ok := sess.Values[key]; ok {
 			data, result := v.(string)
@@ -102,14 +117,12 @@ func (s *session) GetValue(key string) string {
 	return ""
 }
 
-// SetAccount sets account data in session.
-func (s *session) SetAccount(account *model.Account) error {
-	return s.SetValue(Account, account)
+func (s *session) SetAccount(c echo.Context, account *model.Account) error {
+	return s.SetValue(c, Account, account)
 }
 
-// GetAccount returns account object of session.
-func (s *session) GetAccount() *model.Account {
-	if v := s.GetValue(Account); v != "" {
+func (s *session) GetAccount(c echo.Context) *model.Account {
+	if v := s.GetValue(c, Account); v != "" {
 		a := &model.Account{}
 		_ = json.Unmarshal([]byte(v), a)
 		return a

--- a/test/unittest_util.go
+++ b/test/unittest_util.go
@@ -78,7 +78,7 @@ func createConfig(isSecurity bool) *config.Config {
 
 func initContainer(conf *config.Config, logger logger.Logger) container.Container {
 	rep := repository.NewBookRepository(logger, conf)
-	sess := session.NewSession()
+	sess := session.NewSession(logger, conf)
 	messages := map[string]string{
 		"ValidationErrMessageBookTitle": "Please enter the title with 3 to 50 characters.",
 		"ValidationErrMessageBookISBN":  "Please enter the ISBN with 10 to 20 characters."}


### PR DESCRIPTION
### Fixes #[ISSUE NUMBER].
No related issue

Changes proposed in this pull request:
First of all, thank you to show nice sample. It was very helpful to build echo project.
But, I found a problem that session in container has shared struct "context".
It makes race condition and cause data error or concurrent map writes.
The first commit is POC of race condition error that never want it to happen.
If remove `time.Sleep(1 * time.Second)` in second goroutine, you may see also concurrent map writes sometimes.
So, I fixed it to do not use context sharing and use it as parameter.
Now there is a restriction of using session to use echo.context makes can not use in service layer, but there is no reason to access session in business logic, so it it not problem of this structure.
Please comment if you have any question about it.